### PR TITLE
Jml hunt

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -10,10 +10,11 @@ dependency "vmc-d" version="~>1.1.1"
 dependency "fghj" version="~>1.0.0"
 
 configuration "default" {
+    versions "JML"
+    dependency "hunt-http" version="~>0.8.2"
+}
+
+configuration "nojml" {
     targetType "library"
 }
 
-configuration "jml" {
-    versions "JML"
-    dependency "vibe-d" version="~>0.9.4"
-}

--- a/source/ft/adaptors/jinsmemelogger.d
+++ b/source/ft/adaptors/jinsmemelogger.d
@@ -204,7 +204,7 @@ public:
 
     override
     bool isRunning() {
-        return server !is null && server.isRunning(); //receivingThread !is null;
+        return server !is null && server.isRunning();
     }
 
     override


### PR DESCRIPTION
Updates
- Updated JINS MEME Logger module to use hunt-http instead of vibe.d
- Enabled JML by default in dub.sdl

Known Issue
- Background threads of hunt-http doesn't exit even when server is stopped, so once JML is started, caller should exit by exit(0) system call explicitly.