### PR TITLE
Use TaskCondition to handle event loop on web adaptors

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -15,5 +15,5 @@ configuration "default" {
 
 configuration "web-adaptors" {
     versions "JML" "WebHookAdaptor"
-    dependency "vibe-d" version="~>0.9.4"
+    dependency "vibe-d:http" version="~>0.9.5"
 }


### PR DESCRIPTION
Reimplemented the work from #10 following the [advice](https://github.com/vibe-d/vibe-core/issues/324#issuecomment-1267162991) received after asking the vibe-d community.

This PR should fix web adaptors from locking the app on close and also reduce the app dependency footprint.