### PR TITLE
Change WebHook Adaptor isReceivingData behaviour

### DIFF
--- a/source/ft/adaptors/webhook.d
+++ b/source/ft/adaptors/webhook.d
@@ -94,7 +94,7 @@ public:
         }
 
         tsdata.set(data);
-        res.writeVoidBody();
+        res.writeBody("");
     }
 
     void receiveThread() {

--- a/source/ft/adaptors/webhook.d
+++ b/source/ft/adaptors/webhook.d
@@ -146,19 +146,18 @@ public:
             mutex = null;
             condition = null;
             receivingThread = null;
+            gotDataFromFetch = false;
         }
     }
 
     override
     void poll() {
         if (tsdata.updated) {
-            gotDataFromFetch = true;
             WebHookData data = tsdata.get();
+            gotDataFromFetch = data.data.length > 0;
             foreach(string key, float value; data.data) {
                 blendshapes[key] = value;
             }
-        } else {
-            gotDataFromFetch = false;
         }
     }
 


### PR DESCRIPTION
This basically changes what is reported by the `isReceivingData` method. 
* The current behaviour is that it returns `true` when there is buffered data to be processed and `false` if there is no data to process. 
* With this change it will return `true` if the latest package received has new data, and `false` if the latest package received has no data (empty json).

This was done with the consideration that the `isReceivingData` method is used by session to pick which zone to use as active.

Also I fixed a small issue regarding the use of [`res.writeVoidBody()`](https://vibed.org/api/vibe.http.server/HTTPServerResponse.writeVoidBody) instead of [`res.writeBody("")`](https://vibed.org/api/vibe.http.server/HTTPServerResponse.writeBody) when processing HTTPRequests.

### Example

Considering that there are 2 zones, one has a `Web Hook Receiver` listening on 8081 and the other one a `Web Hook Receiver` listening on 8082, this would send different values on both zones and change which zone is the active one. Before the blendshape value would just flash on and off because the zones would be deactivated after it processes each command 

```bash
curl -X POST http://localhost:8081/blendshapes --json '{"tgl_angry": 0.0, "tgl_happy": 1.0}'
curl -X POST http://localhost:8082/blendshapes --json '{"tgl_angry": 1.0, "tgl_happy": 0.0}'
curl -X POST http://localhost:8081/blendshapes --json '{}'
curl -X POST http://localhost:8082/blendshapes --json '{}'
```


