### PR TITLE
Hide PhizAdaptor correctly behind the web-adaptors config

### DIFF
--- a/source/ft/adaptors/package.d
+++ b/source/ft/adaptors/package.d
@@ -2,7 +2,6 @@ module ft.adaptors;
 import ft.adaptor;
 public import ft.adaptors.vmc : VMCAdaptor;
 public import ft.adaptors.phizosc : PhizOSCAdaptor;
-public import ft.adaptors.phiz : PhizAdaptor;
 public import ft.adaptors.vtsproto : VTSAdaptor;
 public import ft.adaptors.openseeface : OSFAdaptor;
 public import ft.adaptors.ifacialmocap : IFMAdaptor;
@@ -13,6 +12,9 @@ version (WebHookAdaptor){
 }
 version (JML) {
     public import ft.adaptors.jinsmemelogger : JMLAdaptor;
+}
+version (Phiz) {
+    public import ft.adaptors.phiz : PhizAdaptor;
 }
 
 private {


### PR DESCRIPTION
Phiz adaptor depends on vibe-d, so it needs to hide correctly behind the web-adaptors config, this PR fixes that.