### PR TITLE
Update vibe-d dependency to use vibe-html instead

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -15,5 +15,5 @@ configuration "default" {
 
 configuration "web-adaptors" {
     versions "JML" "WebHookAdaptor" "Phiz"
-    dependency "vibe-d:http" version="~>0.9.5"
+    dependency "vibe-http" version="~>1.1.2"
 }


### PR DESCRIPTION
vibe-d 0.10 released, and between the changes they separated the html functionality to a [standalone library](https://github.com/vibe-d/vibe-http).

This PR updates that dependency.